### PR TITLE
Dockerfile support for integration with WebAPI

### DIFF
--- a/sample/docker/Dockerfile
+++ b/sample/docker/Dockerfile
@@ -1,14 +1,12 @@
 FROM node:8.16
 
-WORKDIR /griddb-datasource
+RUN git clone https://github.com/griddb/griddb-datasource && \
+    cd griddb-datasource && \
+    npm install -g yarn && \
+    yarn install && \
+    yarn build
 
-COPY . .
-
-RUN npm install -g yarn
-RUN yarn install
-RUN yarn build
-
-FROM grafana/grafana:6.2.0
+FROM grafana/grafana:latest
 
 COPY --from=0 /griddb-datasource/dist /var/lib/grafana/plugins/griddb-plugin
 CMD ["/run.sh"]

--- a/sample/docker/Dockerfile.griddb
+++ b/sample/docker/Dockerfile.griddb
@@ -1,0 +1,44 @@
+FROM centos:7
+
+ENV GRIDDB_VERSION 4.2.1
+ENV DOWNLOAD_URL=https://github.com/griddb/griddb_nosql/releases/download/v${GRIDDB_VERSION}/griddb_nosql-${GRIDDB_VERSION}-1.linux.x86_64.rpm
+ENV CLUSTER_NAME test
+ENV GRIDDB_ADMIN_PASSWORD admin
+ENV GS_HOME /var/lib/gridstore
+ENV GS_LOG $GS_HOME/log
+
+RUN yum install -y curl python git maven vim openjdk-8-jdk-headless
+
+# Install GridDB
+RUN curl ${DOWNLOAD_URL} --output griddb_nosql.linux.x86_64.rpm --silent --location && \
+    rpm -ivh griddb_nosql.linux.x86_64.rpm && \
+# Setup password
+    gs_passwd admin -p ${GRIDDB_ADMIN_PASSWORD} && \
+# Set up cluster name
+    sed -i -e s/\"clusterName\":\"\"/\"clusterName\":\"${CLUSTER_NAME}\"/g \
+        /var/lib/gridstore/conf/gs_cluster.json && \
+    chown -R gsadm:gridstore $GS_HOME
+
+# Build WebAPI
+RUN git clone https://github.com/griddb/webapi.git && \
+    cp /usr/griddb-${GRIDDB_VERSION}/bin/gridstore-${GRIDDB_VERSION}.jar /webapi/lib/gridstore.jar && \
+    sed -i -e 's|^adminHome=.*|adminHome=${GRIDDB_WEBAPI_HOME:/var/lib/gridstore/webapi}|' \
+        /webapi/webapi-ce/src/main/resources/application.properties && \
+    sed -i -e 's/"name".*/"name": "'$CLUSTER_NAME'",/' /webapi/conf/repository.json && \
+    cd /webapi/webapi-ce && \
+    ./gradlew build -x test --stacktrace
+
+# Build sample data inserting tool
+RUN git clone https://github.com/griddb/griddb-datasource && \
+    sed -i -e "s/^clusterName=.*/clusterName=$CLUSTER_NAME/" \
+        /griddb-datasource/sample/SampleData/src/main/resources/griddb.properties && \
+    cd /griddb-datasource/sample/SampleData && \
+    mvn package
+
+# More setup
+ADD start.sh /start.sh
+RUN chmod +x /start.sh
+
+EXPOSE 8080
+
+CMD ["/start.sh"]

--- a/sample/docker/docker-compose.yml
+++ b/sample/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  grafana_plugin:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: grafana
+    ports:
+      - 3000:3000
+    depends_on:
+      - griddb_webapi
+  griddb_webapi:
+    build:
+      context: .
+      dockerfile: Dockerfile.griddb
+    container_name: griddb_webapi
+    ports:
+      - 8080:8080

--- a/sample/docker/start.sh
+++ b/sample/docker/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+# Start GridDB
+echo "Start node"
+su - gsadm -c "gs_startnode -w 5 -u admin/admin"
+echo "Join cluster"
+su - gsadm -c "gs_joincluster -c test -n 1 -u admin/admin"
+
+# Insert data
+echo "Insert data"
+java -jar /griddb-datasource/sample/SampleData/target/SampleData.jar
+
+# Start WebAPI
+echo "Run WebAPI"
+export GRIDDB_WEBAPI_HOME=/webapi
+export LOADER_PATH=/webapi/lib/gridstore.jar
+java -jar /webapi/webapi-ce/build/libs/griddb-webapi-ce-2.0.0.jar &
+
+tail -f /dev/null


### PR DESCRIPTION
Sorry I cannot reopen PR#4. So I create new one.

Because GridDB datasource depends on WebAPI, so a compose app
may help new user have a quick look on function of GridDB datasource.

To start compose app:
`$ docker-compose up -d`

Next, access Grafana at `http://[Docker host address]:3000` and configure datasource
with setting parameters:
Host: `http://[Docker host address]:8080`
Cluster: `test`
User: `admin`
Password: `admin`